### PR TITLE
Add ability to replace source with target

### DIFF
--- a/lib/logstash/filters/useragent.rb
+++ b/lib/logstash/filters/useragent.rb
@@ -73,6 +73,8 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
       if @target.nil?
         # default write to the root of the event
         target = event
+      elsif @target == @source
+        target = event[@source] = {}
       else
         target = event[@target] ||= {}
       end

--- a/spec/filters/useragent_spec.rb
+++ b/spec/filters/useragent_spec.rb
@@ -40,4 +40,23 @@ describe LogStash::Filters::UserAgent do
       insist { subject["minor"] } == "0"
     end
   end
+
+  describe "Replace source with target" do
+    config <<-CONFIG
+      filter {
+        useragent {
+          source => "message"
+          target => "message"
+        }
+      }
+    CONFIG
+
+    sample "Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.63 Safari/537.31" do
+      insist { subject }.include?("message")
+      insist { subject["message"]["name"] } == "Chrome"
+      insist { subject["message"]["os"] } == "Linux"
+      insist { subject["message"]["major"] } == "26"
+      insist { subject["message"]["minor"] } == "0"
+    end
+  end
 end


### PR DESCRIPTION
Accomplish this by configuring the same field as the source and target. 

e.g.

```
filter {
  useragent {
    source => "useragent"
    target => "useragent"
  }
}
```