### PR TITLE
bump version to 1.0.1

### DIFF
--- a/logstash-filter-useragent.gemspec
+++ b/logstash-filter-useragent.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-useragent'
-  s.version         = '1.0.0'
+  s.version         = '1.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parse user agent strings into structured data based on BrowserScope data"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The last mass update of the plugin didnt include the vendored file
we have to bump the version and push a newer one.