### PR TITLE
Add LRU cache to speedup UA lookups (3.7x speedup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+* 1.1.0
+  - Add LRU cache 

--- a/lib/logstash/filters/useragent.rb
+++ b/lib/logstash/filters/useragent.rb
@@ -119,22 +119,21 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
 
     # Calls in here use #dup because there's potential for later filters to modify these values
     # and corrupt the cache. See uap source here for details https://github.com/ua-parser/uap-ruby/tree/master/lib/user_agent_parser
-    if ua_data.os
+    if (os = ua_data.os)
       # The OS is a rich object
       target[@prefix + "os"] = ua_data.os.to_s.dup.force_encoding(Encoding::UTF_8)
+      target[@prefix + "os_name"] = os.name.dup.force_encoding(Encoding::UTF_8) if os.name
 
       # These are all strings
-      if (os = ua_data.os) && (os_version = os.version)
-        target[@prefix + "os_name"] = ua_data.os.name.dup.force_encoding(Encoding::UTF_8) if os.name
-        target[@prefix + "os_major"] = ua_data.os.version.major.dup.force_encoding(Encoding::UTF_8) if os_version.major
-        target[@prefix + "os_minor"] = ua_data.os.version.minor.dup.force_encoding(Encoding::UTF_8) if os_version.minor
+      if (os_version = os.version)
+        target[@prefix + "os_major"] = os_version.major.dup.force_encoding(Encoding::UTF_8) if os_version.major
+        target[@prefix + "os_minor"] = os_version.minor.dup.force_encoding(Encoding::UTF_8) if os_version.minor
       end
     end
 
-    target[@prefix + "device"] = ua_data.device.to_s.dup.force_encoding(Encoding::UTF_8) if not ua_data.device.nil?
+    target[@prefix + "device"] = ua_data.device.to_s.dup.force_encoding(Encoding::UTF_8) if ua_data.device
 
-    if ua_data.version
-      ua_version = ua_data.version
+    if (ua_version = ua_data.version)
       target[@prefix + "major"] = ua_version.major.dup.force_encoding(Encoding::UTF_8) if ua_version.major
       target[@prefix + "minor"] = ua_version.minor.dup.force_encoding(Encoding::UTF_8) if ua_version.minor
       target[@prefix + "patch"] = ua_version.patch.dup.force_encoding(Encoding::UTF_8) if ua_version.patch

--- a/lib/logstash/filters/useragent.rb
+++ b/lib/logstash/filters/useragent.rb
@@ -41,7 +41,12 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
   # UA parsing is surprisingly expensive. This filter uses an LRU cache to take advantage of the fact that
   # user agents are often found adjacent to one another in log files and rarely have a random distribution.
   # The higher you set this the more likely an item is to be in the cache and the faster this filter will run.
-  # However, if you set this too high you can use more memory than desired
+  # However, if you set this too high you can use more memory than desired.
+  #
+  # Experiment with different values for this option to find the best performance for your dataset.
+  #
+  # This MUST be set to a value > 0. There is really no reason to not want this behavior, the overhead is minimal
+  # and the speed gains are huge.
   config :lru_cache_size, :validate => :number, :default => 1000
 
   public

--- a/lib/logstash/filters/useragent.rb
+++ b/lib/logstash/filters/useragent.rb
@@ -46,7 +46,12 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
   # Experiment with different values for this option to find the best performance for your dataset.
   #
   # This MUST be set to a value > 0. There is really no reason to not want this behavior, the overhead is minimal
-  # and the speed gains are huge.
+  # and the speed gains are large.
+  #
+  # It is important to note that this config value is global. That is to say all instances of the user agent filter
+  # share the same cache. The last declared cache size will 'win'. The reason for this is that there would be no benefit
+  # to having multiple caches for different instances at different points in the pipeline, that would just increase the
+  # number of cache misses and waste memory.
   config :lru_cache_size, :validate => :number, :default => 1000
 
   public

--- a/logstash-filter-useragent.gemspec
+++ b/logstash-filter-useragent.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-useragent'
-  s.version         = '1.0.1'
+  s.version         = '1.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parse user agent strings into structured data based on BrowserScope data"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-filter-useragent.gemspec
+++ b/logstash-filter-useragent.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
   s.add_runtime_dependency 'user_agent_parser', ['>= 2.0.0']
-  s.add_runtime_dependency 'lru_redux'
+  s.add_runtime_dependency 'lru_redux', "~> 1.1.0"
   s.add_development_dependency 'logstash-devutils'
 end
 

--- a/logstash-filter-useragent.gemspec
+++ b/logstash-filter-useragent.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
   s.add_runtime_dependency 'user_agent_parser', ['>= 2.0.0']
+  s.add_runtime_dependency 'lru_redux'
   s.add_development_dependency 'logstash-devutils'
 end
 

--- a/spec/filters/useragent_spec.rb
+++ b/spec/filters/useragent_spec.rb
@@ -68,7 +68,7 @@ describe LogStash::Filters::UserAgent do
       "minor" => lambda {|uad| uad.version.minor},
       "patch" => lambda {|uad| uad.version.patch},
       "build" => lambda {|uad| uad.version.patch_minor}
-    }.each do |field,uad_getter|
+    }.each do |field, uad_getter|
       context "for the #{field} field" do
         let(:value) {uad_getter.call(ua_data)}
         let(:target_field) { target[field]}

--- a/spec/filters/useragent_spec.rb
+++ b/spec/filters/useragent_spec.rb
@@ -40,4 +40,51 @@ describe LogStash::Filters::UserAgent do
       insist { subject["minor"] } == "0"
     end
   end
+
+  describe "LRU object identity" do
+    let(:uafilter) { LogStash::Filters::UserAgent.new("source" => "foo") }
+    let(:ua_data) {
+      uafilter.lookup_useragent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.85 Safari/537.36")
+    }
+    subject(:target) { {} }
+
+    before do
+      uafilter.register
+
+      # Stub this out because this UA doesn't have this field
+      allow(ua_data.version).to receive(:patch_minor).and_return("foo")
+
+      uafilter.write_to_target(target, ua_data)
+    end
+
+    {
+      "name" => lambda {|uad| uad.name},
+      "os" => lambda {|uad| uad.os.to_s},
+      "os_name" => lambda {|uad| uad.os.name},
+      "os_major" => lambda {|uad| uad.os.version.major},
+      "os_minor" => lambda {|uad| uad.os.version.minor},
+      "device" => lambda {|uad| uad.device.to_s},
+      "major" => lambda {|uad| uad.version.major},
+      "minor" => lambda {|uad| uad.version.minor},
+      "patch" => lambda {|uad| uad.version.patch},
+      "build" => lambda {|uad| uad.version.patch_minor}
+    }.each do |field,uad_getter|
+      context "for the #{field} field" do
+        let(:value) {uad_getter.call(ua_data)}
+        let(:target_field) { target[field]}
+
+        it "should not have a nil value" do
+          expect(target_field).to be_truthy
+        end
+
+        it "should have equivalent values" do
+          expect(target_field).to eql(value)
+        end
+
+        it "should dup/clone the field to prevent cache corruption" do
+          expect(target_field.object_id).not_to eql(value.object_id)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This implements an LRU cache per #5 . I got pretty irritated with this filter dragging down the performance of my benchmarks for the ES gem so I added this small patch.

Performance went up ~3.7x from

`~/D/logstash-1.5.4 $ sh -c 'sleep 60 && killall -9 java' & bin/logstash -w2 -f complete_ua.conf | pv -l > /dev/null
 209k 0:01:00 [3.48k/s]
`

To 

`~/D/logstash-1.5.4 $ sh -c 'sleep 60 && killall -9 java' & bin/logstash -w2 -f complete_ua.conf | pv -l > /dev/null
 775k 0:01:00 [12.9k/s]`