### PR TITLE
Do not lookup useragent if empty

### DIFF
--- a/lib/logstash/filters/useragent.rb
+++ b/lib/logstash/filters/useragent.rb
@@ -83,6 +83,8 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
     useragent = event[@source]
     useragent = useragent.first if useragent.is_a? Array
 
+    return if useragent.nil? or useragent.empty?
+
     begin
       ua_data = lookup_useragent(useragent)
     rescue StandardError => e
@@ -149,4 +151,3 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
   end
 
 end # class LogStash::Filters::UserAgent
-

--- a/spec/filters/useragent_spec.rb
+++ b/spec/filters/useragent_spec.rb
@@ -41,6 +41,25 @@ describe LogStash::Filters::UserAgent do
     end
   end
 
+  describe "Without user agent" do
+    config <<-CONFIG
+      filter {
+        useragent {
+          source => "message"
+          target => "ua"
+        }
+      }
+    CONFIG
+
+    sample "foo" => "bar" do
+      reject { subject }.include?("ua")
+    end
+
+    sample "" do
+      reject { subject }.include?("ua")
+    end
+  end
+
   describe "LRU object identity" do
     let(:uafilter) { LogStash::Filters::UserAgent.new("source" => "foo") }
     let(:ua_data) {


### PR DESCRIPTION
Without this PR, when no useragent field exists, I end up with `browser.device=Other`, `browser.name=Other`, `browser.os=Other` and `browser.os_name=Other`.
