### PR TITLE
Clean up logstash-core dependency version

### DIFF
--- a/logstash-filter-useragent.gemspec
+++ b/logstash-filter-useragent.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
+  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"
 
   s.add_runtime_dependency 'user_agent_parser', ['>= 2.0.0']
   s.add_runtime_dependency 'lru_redux', "~> 1.1.0"


### PR DESCRIPTION
Now that the release is cut. 