### PR TITLE
Simple Linux and OS name.

### DIFF
--- a/lib/logstash/filters/useragent.rb
+++ b/lib/logstash/filters/useragent.rb
@@ -9,6 +9,13 @@ require "tempfile"
 # UserAgent filter, adds information about user agent like family, operating
 # system, version, and device
 #
+
+LINUX = ["Ubuntu", "Kubuntu", "Arch Linux", "CentOS", "Slackware", "Gentoo",
+         "openSUSE", "SUSE", "Red Hat", "Fedora", "PCLinuxOS", "Gentoo",
+         "Mageia", "BackTrack", "Lubuntu", "Puppy"]
+SIMPLE_OS = ["iOS", "Mac OS X", "Android", "Windows Phone", "Windows",
+             "BlackBerry", "Symbian"]
+
 # Logstash releases ship with the regexes.yaml database made available from
 # ua-parser with an Apache 2.0 license. For more details on ua-parser, see
 # <https://github.com/tobie/ua-parser/>.
@@ -137,6 +144,15 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
       if (os_version = os.version)
         target[@prefix + "os_major"] = os_version.major.dup.force_encoding(Encoding::UTF_8) if os_version.major
         target[@prefix + "os_minor"] = os_version.minor.dup.force_encoding(Encoding::UTF_8) if os_version.minor
+      end
+
+      simple_name = SIMPLE_OS.find {|e| target[@prefix + "os_name"].start_with?(e) }
+      if simple_name
+        target[@prefix + "os_simple_name"] = simple_name
+      elsif LINUX.include? target[@prefix + "os_name"]
+        target[@prefix + "os_simple_name"] = "Linux"
+      else
+        target[@prefix + "os_simple_name"] = target[@prefix + "os_name"]
       end
     end
 

--- a/spec/filters/useragent_spec.rb
+++ b/spec/filters/useragent_spec.rb
@@ -125,4 +125,51 @@ describe LogStash::Filters::UserAgent do
       insist { subject["message"]["minor"] } == "0"
     end
   end
+
+  describe "Simple name" do
+    config <<-CONFIG
+      filter {
+        useragent {
+          source => "message"
+          target => "ua"
+        }
+      }
+    CONFIG
+
+    sample "Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.63 Safari/537.31" do
+      insist { subject }.include?("ua")
+      insist { subject["ua"]["os_simple_name"] } == "Linux"
+    end
+
+    sample "Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) GSA/5.4.49956 Mobile/11D257 Safari/9537.53" do
+      insist { subject }.include?("ua")
+      insist { subject["ua"]["os_simple_name"] } == "iOS"
+    end
+
+    sample "Mozilla/5.0 (Linux; Android 4.2.2; C2305 Build/16.0.B.2.16) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36" do
+      insist { subject }.include?("ua")
+      insist { subject["ua"]["os_simple_name"] } == "Android"
+    end
+
+    sample "Mozilla/5.0 (BlackBerry; U; BlackBerry 9720; en-GB) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.1083 Mobile Safari/534.11+" do
+      insist { subject }.include?("ua")
+      insist { subject["ua"]["os_simple_name"] } == "BlackBerry"
+    end
+
+    sample "Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; Lumia 535 Dual SIM) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537" do
+      insist { subject }.include?("ua")
+      insist { subject["ua"]["os_simple_name"] } == "Windows Phone"
+    end
+
+    sample "Opera/9.80 (Series 60; Opera Mini/6.5.27309/27.1169; U; ru) Presto/2.8.119 Version/11.10" do
+      insist { subject }.include?("ua")
+      insist { subject["ua"]["os_simple_name"] } == "Symbian"
+    end
+
+    sample "Mozilla/5.0 (X11; U; Linux i686; en-GB; rv:1.7.6) Gecko/20050405 Epiphany/1.6.1 (Ubuntu) (Ubuntu package 1.0.2)" do
+      insist { subject }.include?("ua")
+      insist { subject["ua"]["os_simple_name"] } == "Linux"
+    end
+  end
+
 end


### PR DESCRIPTION
The [pull request #4](https://github.com/logstash-plugins/logstash-filter-useragent/pull/4) is broken with the cache. Here is a fresh version. This patch gives simple linux and os name, for better bucketizing.
