### PR TITLE
synchronize useragent parser for thread safety

### DIFF
--- a/logstash-filter-useragent.gemspec
+++ b/logstash-filter-useragent.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Files
-  s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
+  s.files = Dir['lib/**/*','spec/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
 
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})

--- a/logstash-filter-useragent.gemspec
+++ b/logstash-filter-useragent.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-useragent'
-  s.version         = '2.0.6'
+  s.version         = '2.0.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parse user agent strings into structured data based on BrowserScope data"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
fixes #25 

wrap `UserAgentParser::Parser#parser` in a mutex to avoid thread safety issues. The real cause seems to be related to the underlying JRuby regex code that is not thread safe but in any case, this is pretty much this only fix possible at this point.

I have manually confirmed that this solves the problem. using a big enough dataset (>= 5000 lines) and using multiple workers, a few random errors are usually triggered. Using this fix (or setting the number of workers to 1) the error in never triggered. 