### PR TITLE
#42 fix manual yaml file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.1
+  - Fixed an issue preventing the plugin from working with a custom regex yaml file.
+
 ## 3.1.0
   - Parser performance increase of a factor of about 2.5 by moving core parser logic from Ruby to Java
   - Lower memory footprint of Java implementation allowed for increasing the default parser cache size from 1k to 100k

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ apply plugin: "distribution"
 apply plugin: "idea"
 
 group "org.logstash.filters"
-version "3.1.0"
+version "3.1.1"
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 

--- a/lib/logstash-filter-useragent_jars.rb
+++ b/lib/logstash-filter-useragent_jars.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 
 require 'jar_dependencies'
-require_jar('org.logstash.filters', 'logstash-filter-useragent', '3.1.0')
+require_jar('org.logstash.filters', 'logstash-filter-useragent', '3.1.1')

--- a/lib/logstash/filters/useragent.rb
+++ b/lib/logstash/filters/useragent.rb
@@ -61,9 +61,7 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
       @parser = org.logstash.uaparser.CachingParser.new(lru_cache_size)
     else
       @logger.debug("Using user agent regexes", :regexes => @regexes)
-      yaml = ::File.open(regexes, "rb")
-      @parser = org.logstash.uaparser.CachingParser.new(yaml.read, lru_cache_size)
-      yaml.close
+      @parser = org.logstash.uaparser.CachingParser.new(@regexes, lru_cache_size)
     end
 
     # make @target in the format [field name] if defined, i.e. surrounded by brakets

--- a/logstash-filter-useragent.gemspec
+++ b/logstash-filter-useragent.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-useragent'
-  s.version         = '3.1.0'
+  s.version         = '3.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Parse user agent strings into structured data based on BrowserScope data"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/useragent_spec.rb
+++ b/spec/filters/useragent_spec.rb
@@ -24,6 +24,26 @@ describe LogStash::Filters::UserAgent do
     end
   end
 
+  describe "manually specified regexes file" do
+    config <<-CONFIG
+      filter {
+        useragent {
+          source => "message"
+          target => "ua"
+          regexes => "build/resources/main/regexes.yaml"
+        }
+      }
+    CONFIG
+
+    sample "Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.63 Safari/537.31" do
+      insist { subject }.include?("ua")
+      insist { subject.get("[ua][name]") } == "Chrome"
+      insist { subject.get("[ua][os]") } == "Linux"
+      insist { subject.get("[ua][major]") } == "26"
+      insist { subject.get("[ua][minor]") } == "0"
+    end
+  end
+  
   describe "Without target field" do
     config <<-CONFIG
       filter {

--- a/src/main/java/org/logstash/uaparser/CachingParser.java
+++ b/src/main/java/org/logstash/uaparser/CachingParser.java
@@ -18,7 +18,10 @@
 package org.logstash.uaparser;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Map;
 import org.apache.commons.collections4.map.LRUMap;
 
@@ -43,7 +46,14 @@ public final class CachingParser extends Parser {
         this(new Parser(), cacheSize);
     }
 
-    public CachingParser(String regexYaml) {
+    public CachingParser(String yamlPath, final int cacheSize) throws IOException {
+        this(
+            new Parser(new ByteArrayInputStream(Files.readAllBytes(Paths.get(yamlPath)))),
+            cacheSize
+        );
+    }
+    
+    CachingParser(String regexYaml) {
         this(
             new Parser(new ByteArrayInputStream(regexYaml.getBytes(StandardCharsets.UTF_8)))
         );


### PR DESCRIPTION
closes #42 

* Forgot to add constructor for manually specifying yaml path to Java side of things, did so now and moved the complete logic of reading the yaml file to Java.
* Added spec for the reported bug in #42 