### PR TITLE
Fix windows version number extraction

### DIFF
--- a/lib/logstash/filters/useragent.rb
+++ b/lib/logstash/filters/useragent.rb
@@ -129,10 +129,8 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
       event.set(@prefixed_os_name, os.family.dup.force_encoding(Encoding::UTF_8)) if os.family
 
       # These are all strings
-      if os.minor && os.major
-        event.set(@prefixed_os_major, os.major.dup.force_encoding(Encoding::UTF_8)) if os.major
-        event.set(@prefixed_os_minor, os.minor.dup.force_encoding(Encoding::UTF_8)) if os.minor
-      end
+      event.set(@prefixed_os_major, os.major.dup.force_encoding(Encoding::UTF_8)) if os.major
+      event.set(@prefixed_os_minor, os.minor.dup.force_encoding(Encoding::UTF_8)) if os.minor
     end
 
     event.set(@prefixed_device, ua_data.device.to_s.dup.force_encoding(Encoding::UTF_8)) if ua_data.device

--- a/spec/filters/useragent_spec.rb
+++ b/spec/filters/useragent_spec.rb
@@ -33,6 +33,23 @@ describe LogStash::Filters::UserAgent do
       insist { subject.get("[ua][os_major]") } == "10"
       insist { subject.get("[ua][os_minor]") } == "14"
     end
+
+    # windows
+    sample "Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246" do
+      insist { subject }.include?("ua")
+      insist { subject.get("[ua][os]") } == "Windows"
+      insist { subject.get("[ua][os_name]") } == "Windows"
+      insist { subject.get("[ua][os_major]") } == "8"
+      insist { subject.get("[ua][os_minor]") } == "1"
+    end
+
+    sample "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246" do
+      insist { subject }.include?("ua")
+      insist { subject.get("[ua][os]") } == "Windows"
+      insist { subject.get("[ua][os_name]") } == "Windows"
+      insist { subject.get("[ua][os_major]") } == "10"
+      insist { subject.get("[ua][os_minor]") } == nil
+    end
   end
 
   describe "manually specified regexes file" do


### PR DESCRIPTION
The parser doesn't always return a minor OS version number – for example Windows 10 or Windows 7. In these cases _both_ of the fields `ua.os_major` _and_ `ua.os_minor` would be missing.

Don't require both major and minor os version numbers to be present in order to set either one.

Includes additional tests with user agent strings from the windows platform.