### PR TITLE
Feat: support ECS mode when setting UA fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 3.3.0 (pending)
+## 3.3.0
+ - Feat: support ECS mode when setting UA fields [#68](https://github.com/logstash-plugins/logstash-filter-useragent/pull/68)
+ 
  - Fix: capture os major version + update UA regexes [#69](https://github.com/logstash-plugins/logstash-filter-useragent/pull/69)
 
    The UA parser *regexes.yaml* update (to **v0.12.0**) will accurately detect recent user agent strings.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -22,12 +22,12 @@ include::{include_path}/plugin_header.asciidoc[]
 
 Parse user agent strings into structured data based on BrowserScope data
 
-UserAgent filter, adds information about user agent like family, operating
-system, version, and device
+UserAgent filter, adds information about user agent like name, version, operating
+system, and device.
 
 Logstash releases ship with the regexes.yaml database made available from
 ua-parser with an Apache 2.0 license. For more details on ua-parser, see
-<https://github.com/tobie/ua-parser/>.
+<https://github.com/ua-parser/uap-core/>.
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Useragent Filter Configuration Options
@@ -37,6 +37,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-lru_cache_size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-prefix>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-regexes>> |<<string,string>>|No
@@ -49,11 +50,25 @@ filter plugins.
 
 &nbsp;
 
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+* Value type is <<string,string>>
+* Supported values are:
+** `disabled`: does not use ECS-compatible field names (fields might be set at the root of the event)
+** `v1`: uses fields that are compatible with Elastic Common Schema (for example, `[user_agent][version]`)
+* Default value depends on which version of Logstash is running:
+** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+The value of this setting affects the _default_ value of <<plugins-{type}s-{plugin}-target>>.
+
 [id="plugins-{type}s-{plugin}-lru_cache_size"]
 ===== `lru_cache_size` 
 
   * Value type is <<number,number>>
-  * Default value is `1000`
+  * Default value is `100000`
 
 UA parsing is surprisingly expensive. This filter uses an LRU cache to take advantage of the fact that
 user agents are often found adjacent to one another in log files and rarely have a random distribution.
@@ -84,10 +99,8 @@ A string to prepend to all of the extracted keys
   * Value type is <<string,string>>
   * There is no default value for this setting.
 
-`regexes.yaml` file to use
-
 If not specified, this will default to the `regexes.yaml` that ships
-with logstash.
+with logstash. Otherwise use the provided `regexes.yaml` file.
 
 You can find the latest version of this here:
 <https://github.com/ua-parser/uap-core/blob/master/regexes.yaml>
@@ -106,7 +119,9 @@ array, only the first value will be used.
 ===== `target` 
 
   * Value type is <<string,string>>
-  * There is no default value for this setting.
+  * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+    ** ECS Compatibility disabled: no default value for this setting
+    ** ECS Compatibility enabled: `"user_agent"`
 
 The name of the field to assign user agent data into.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -50,7 +50,7 @@ output.
 |[os_major] |[@metadata][filter][user_agent][os][version][major] |OS major version |Only as meta-data in ECS mode
 |[os_minor] |[@metadata][filter][user_agent][os][version][minor] |OS minor version |Only as meta-data in ECS mode
 |[os_patch] |[@metadata][filter][user_agent][os][version][patch] |OS patch version |Only as meta-data in ECS mode
-|[os]       |[user_agent][os][full]                              |Full operating-system name |
+|[os_full]  |[user_agent][os][full]                              |Full operating-system name |
 |[device]   |[user_agent][device][name]                          |Device name |
 |=======================================================================
 
@@ -72,9 +72,9 @@ produces the following fields:
         "version"=>"45.0",
         "major"=>"45",
         "minor"=>"0",
-        "os"=>"Mac OS X 10.11"
         "os_name"=>"Mac OS X",
         "os_version"=>"10.11",
+        "os_full"=>"Mac OS X 10.11",
         "os_major"=>"10",
         "os_minor"=>"11",
         "device"=>"Mac"

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -25,9 +25,33 @@ Parse user agent strings into structured data based on BrowserScope data
 UserAgent filter, adds information about user agent like name, version, operating
 system, and device.
 
-Logstash releases ship with the regexes.yaml database made available from
-ua-parser with an Apache 2.0 license. For more details on ua-parser, see
+The plugin ships with the *regexes.yaml* database made available from ua-parser
+with an Apache 2.0 license. For more details on ua-parser, see
 <https://github.com/ua-parser/uap-core/>.
+
+==== Compatibility with the Elastic Common Schema (ECS)
+
+This plugin can be used to parse user-agent (UA) _into_ fields compliant with the Elastic Common Schema.
+It can also be used _without_ ECS, the field mapping differs when ECS is disabled:
+
+[cols="<l,<l,e,<e"]
+|=======================================================================
+|ECS v1 |ECS disabled |Description |Notes
+
+|[user_agent][name]      |[name]    |Detected UA name |
+|[user_agent][version]   | N/A      |Detected UA version |Only available in ECS mode
+|[@metadata][filter][user_agent][version][major] |[major]  |UA major version |Only as meta-data in ECS mode
+|[@metadata][filter][user_agent][version][minor] |[minor]  |UA minor version |Only as meta-data in ECS mode
+|[@metadata][filter][user_agent][version][minor] |[patch]  |UA patch version |Only as meta-data in ECS mode
+|[user_agent][os][name]  |[os_name] |Detected operating-system name |
+|[user_agent][os][version]  | N/A |Detected OS version |Only available in ECS mode
+|[@metadata][filter][user_agent][os][version][major] |[os_major]  |OS major version |Only as meta-data in ECS mode
+|[@metadata][filter][user_agent][os][version][minor] |[os_minor]  |OS minor version |Only as meta-data in ECS mode
+|[@metadata][filter][user_agent][os][version][patch] |[os_patch]  |OS patch version |Only as meta-data in ECS mode
+|[user_agent][os][full]  |[os]      |Full operating-system name |
+|[user_agent][device][name]  |[device]  |Device name |
+
+|=======================================================================
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Useragent Filter Configuration Options
@@ -63,6 +87,50 @@ filter plugins.
 
 Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
 The value of this setting affects the _default_ value of <<plugins-{type}s-{plugin}-target>>.
+
+Example:
+[source,ruby]
+    filter {
+      useragent {
+        source => 'message'
+      }
+    }
+
+Given an event with the `message` field set as: `Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:45.0) Gecko/20100101 Firefox/45.0`
+produces the following fields:
+
+[source,ruby]
+-----
+    {
+        "name"=>"Firefox",
+        "version"=>"45.0",
+        "major"=>"45",
+        "minor"=>"0",
+        "os"=>"Mac OS X 10.11"
+        "os_name"=>"Mac OS X",
+        "os_version"=>"10.11",
+        "os_major"=>"10",
+        "os_minor"=>"11",
+        "device"=>"Mac"
+    }
+-----
+
+**and with ECS enabled:**
+[source,ruby]
+-----
+    {
+        "user_agent"=>{
+            "name"=>"Firefox",
+            "version"=>"45.0",
+            "os"=>{
+                "name"=>"Mac OS X",
+                "version"=>"10.11",
+                "full"=>"Mac OS X 10.11"
+            },
+            "device"=>{"name"=>"Mac"},
+        }
+    }
+-----
 
 [id="plugins-{type}s-{plugin}-lru_cache_size"]
 ===== `lru_cache_size` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -32,61 +32,27 @@ with an Apache 2.0 license. For more details on ua-parser, see
 ==== Compatibility with the Elastic Common Schema (ECS)
 
 This plugin can be used to parse user-agent (UA) _into_ fields compliant with the Elastic Common Schema.
-It can also be used _without_ ECS, the field mapping differs when ECS is disabled:
+Here's how
+<<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> affects
+output.
 
 [cols="<l,<l,e,<e"]
 |=======================================================================
-|ECS v1 |ECS disabled |Description |Notes
+|ECS disabled |ECS v1 |Description |Notes
 
-|[user_agent][name]      |[name]    |Detected UA name |
-|[user_agent][version]   | N/A      |Detected UA version |Only available in ECS mode
-|[@metadata][filter][user_agent][version][major] |[major]  |UA major version |Only as meta-data in ECS mode
-|[@metadata][filter][user_agent][version][minor] |[minor]  |UA minor version |Only as meta-data in ECS mode
-|[@metadata][filter][user_agent][version][minor] |[patch]  |UA patch version |Only as meta-data in ECS mode
-|[user_agent][os][name]  |[os_name] |Detected operating-system name |
-|[user_agent][os][version]  | N/A |Detected OS version |Only available in ECS mode
-|[@metadata][filter][user_agent][os][version][major] |[os_major]  |OS major version |Only as meta-data in ECS mode
-|[@metadata][filter][user_agent][os][version][minor] |[os_minor]  |OS minor version |Only as meta-data in ECS mode
-|[@metadata][filter][user_agent][os][version][patch] |[os_patch]  |OS patch version |Only as meta-data in ECS mode
-|[user_agent][os][full]  |[os]      |Full operating-system name |
-|[user_agent][device][name]  |[device]  |Device name |
-
+|[name]     |[user_agent][name]                                  |Detected UA name |
+| N/A       |[user_agent][version]                               |Detected UA version |Only available in ECS mode
+|[major]    |[@metadata][filter][user_agent][version][major]     |UA major version |Only as meta-data in ECS mode
+|[minor]    |[@metadata][filter][user_agent][version][minor]     |UA minor version |Only as meta-data in ECS mode
+|[patch]    |[@metadata][filter][user_agent][version][minor]     |UA patch version |Only as meta-data in ECS mode
+|[os_name]  |[user_agent][os][name]                              |Detected operating-system name |
+| N/A       |[user_agent][os][version]                           |Detected OS version |Only available in ECS mode
+|[os_major] |[@metadata][filter][user_agent][os][version][major] |OS major version |Only as meta-data in ECS mode
+|[os_minor] |[@metadata][filter][user_agent][os][version][minor] |OS minor version |Only as meta-data in ECS mode
+|[os_patch] |[@metadata][filter][user_agent][os][version][patch] |OS patch version |Only as meta-data in ECS mode
+|[os]       |[user_agent][os][full]                              |Full operating-system name |
+|[device]   |[user_agent][device][name]                          |Device name |
 |=======================================================================
-
-[id="plugins-{type}s-{plugin}-options"]
-==== Useragent Filter Configuration Options
-
-This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
-
-[cols="<,<,<",options="header",]
-|=======================================================================
-|Setting |Input type|Required
-| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-lru_cache_size>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-prefix>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-regexes>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-source>> |<<string,string>>|Yes
-| <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
-|=======================================================================
-
-Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
-filter plugins.
-
-&nbsp;
-
-[id="plugins-{type}s-{plugin}-ecs_compatibility"]
-===== `ecs_compatibility`
-
-* Value type is <<string,string>>
-* Supported values are:
-** `disabled`: does not use ECS-compatible field names (fields might be set at the root of the event)
-** `v1`: uses fields that are compatible with Elastic Common Schema (for example, `[user_agent][version]`)
-* Default value depends on which version of Logstash is running:
-** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
-** Otherwise, the default value is `disabled`.
-
-Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
-The value of this setting affects the _default_ value of <<plugins-{type}s-{plugin}-target>>.
 
 Example:
 [source,ruby]
@@ -131,6 +97,41 @@ produces the following fields:
         }
     }
 -----
+
+[id="plugins-{type}s-{plugin}-options"]
+==== Useragent Filter Configuration Options
+
+This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-lru_cache_size>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-prefix>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-regexes>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-source>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
+|=======================================================================
+
+Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+filter plugins.
+
+&nbsp;
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+* Value type is <<string,string>>
+* Supported values are:
+** `disabled`: does not use ECS-compatible field names (fields might be set at the root of the event)
+** `v1`: uses fields that are compatible with Elastic Common Schema (for example, `[user_agent][version]`)
+* Default value depends on which version of Logstash is running:
+** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+The value of this setting affects the _default_ value of <<plugins-{type}s-{plugin}-target>>.
 
 [id="plugins-{type}s-{plugin}-lru_cache_size"]
 ===== `lru_cache_size` 

--- a/lib/logstash/filters/useragent.rb
+++ b/lib/logstash/filters/useragent.rb
@@ -151,9 +151,7 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
       event.set(@os_minor_field, duped_string(os.minor)) if os.minor
       event.set(@os_patch_field, duped_string(os.patch)) if os.patch
       os_version = build_os_version(os)
-      verified_os_version = check_and_adjust_version(ua_source, os_version)
-      # only set OS version if it's not 'interpreted' (contained in UA string)
-      event.set(@os_version_field, verified_os_version) if verified_os_version
+      event.set(@os_version_field, os_version) if os_version
 
       os_name = os.family
       if os_name

--- a/lib/logstash/filters/useragent.rb
+++ b/lib/logstash/filters/useragent.rb
@@ -37,7 +37,7 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
   config :regexes, :validate => :string
 
   # A string to prepend to all of the extracted keys
-  config :prefix, :validate => :string, :default => ''
+  config :prefix, :validate => :string, :default => '' # not supported in ECS mode
 
   # UA parsing is surprisingly expensive. This filter uses an LRU cache to take advantage of the fact that
   # user agents are often found adjacent to one another in log files and rarely have a random distribution.
@@ -91,6 +91,10 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
   end
 
   def register
+    if ecs_compatibility != :disabled && @prefix && !@prefix.empty?
+      @logger.warn "Field prefix isn't supported in ECS compatibility mode, please remove `prefix => #{@prefix.inspect}`"
+    end
+
     if @regexes.nil?
       @parser = org.logstash.uaparser.CachingParser.new(lru_cache_size)
     else

--- a/lib/logstash/filters/useragent.rb
+++ b/lib/logstash/filters/useragent.rb
@@ -2,7 +2,7 @@
 require "logstash-filter-useragent_jars"
 require "logstash/filters/base"
 require "logstash/namespace"
-require "thread"
+require 'logstash/plugin_mixins/ecs_compatibility_support'
 
 # Parse user agent strings into structured data based on BrowserScope data
 #
@@ -14,6 +14,8 @@ require "thread"
 # <https://github.com/tobie/ua-parser/>.
 class LogStash::Filters::UserAgent < LogStash::Filters::Base
 
+  include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1)
+
   config_name "useragent"
 
   # The field containing the user agent string. If this field is an
@@ -23,7 +25,7 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
   # The name of the field to assign user agent data into.
   #
   # If not specified user agent data will be stored in the root of the event.
-  config :target, :validate => :string
+  config :target, :validate => :string # default [user_agent] in ECS mode
 
   # `regexes.yaml` file to use
   #
@@ -57,19 +59,35 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
     super
 
     # make @target in the format [field name] if defined, i.e. surrounded by brackets
-    target = @target || ''
+    target = @target || ecs_select[disabled: '', v1: '[user_agent]']
     target = "[#{@target}]" if !target.empty? && target !~ /^\[[^\[\]]+\]$/
 
-    # predefine prefixed field names
-    @prefixed_name = "#{target}[#{@prefix}name]"
-    @prefixed_os = "#{target}[#{@prefix}os]"
-    @prefixed_os_name = "#{target}[#{@prefix}os_name]"
-    @prefixed_os_major = "#{target}[#{@prefix}os_major]"
-    @prefixed_os_minor = "#{target}[#{@prefix}os_minor]"
-    @prefixed_device = "#{target}[#{@prefix}device]"
-    @prefixed_major = "#{target}[#{@prefix}major]"
-    @prefixed_minor = "#{target}[#{@prefix}minor]"
-    @prefixed_patch = "#{target}[#{@prefix}patch]"
+    @name_field = ecs_select[disabled: "[#{@prefix}name]", v1: '[name]']
+    @name_field = "#{target}#{@name_field}"
+
+    @device_name_field = ecs_select[disabled: "[#{@prefix}device]", v1: '[device][name]']
+    @device_name_field = "#{target}#{@device_name_field}"
+
+    @version_field = ecs_select[disabled: "[#{@prefix}version]", v1: '[version]']
+    @version_field = "#{target}#{@version_field}"
+    @major_field = ecs_select[disabled: "#{target}[#{@prefix}major]", v1: "[@metadata][filter][user_agent][version][major]"]
+    @minor_field = ecs_select[disabled: "#{target}[#{@prefix}minor]", v1: "[@metadata][filter][user_agent][version][minor]"]
+    @patch_field = ecs_select[disabled: "#{target}[#{@prefix}patch]", v1: "[@metadata][filter][user_agent][version][patch]"]
+
+    @os_full_name_field = ecs_select[disabled: "[#{@prefix}os]", v1: '[os][full]']
+    @os_full_name_field = "#{target}#{@os_full_name_field}"
+
+    @os_name_field = ecs_select[disabled:"[#{@prefix}os_name]", v1: '[os][name]']
+    @os_name_field = "#{target}#{@os_name_field}"
+
+    @os_version_field = ecs_select[disabled: "[#{@prefix}os_version]", v1: '[os][version]']
+    @os_version_field = "#{target}#{@os_version_field}"
+    @os_major_field = ecs_select[disabled: "#{target}[#{@prefix}os_major]", v1: "[@metadata][filter][user_agent][os][version][major]"]
+    @os_minor_field = ecs_select[disabled: "#{target}[#{@prefix}os_minor]", v1: "[@metadata][filter][user_agent][os][version][minor]"]
+    @os_patch_field = ecs_select[disabled: "#{target}[#{@prefix}os_patch]", v1: "[@metadata][filter][user_agent][os][version][patch]"]
+
+    # NOTE: unfortunately we can not reliably provide `user_agent.original` since the patterns do not
+    # reliably give back the matched group and they support the UA string prefixed and/or suffixed
   end
 
   def register
@@ -99,7 +117,7 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
     return unless ua_data
 
     event.remove(@source) if @target == @source
-    set_fields(event, ua_data)
+    set_fields(event, useragent, ua_data)
 
     filter_matched(event)
   end
@@ -107,36 +125,104 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
   private
 
   def lookup_useragent(useragent)
-    # the UserAgentParser::Parser class is not thread safe, indications are that it is probably
-    # caused by the underlying JRuby regex code that is not thread safe.
-    # see https://github.com/logstash-plugins/logstash-filter-useragent/issues/25
     @parser.parse(useragent)
   end
 
-  def set_fields(event, ua_data)
-    # UserAgentParser outputs as US-ASCII.
+  def set_fields(event, ua_source, ua_data)
+    # UserAgentParser strings are US-ASCII
 
-    event.set(@prefixed_name, duped_string(ua_data.userAgent.family))
-    event.set(@prefixed_device, duped_string(ua_data.device)) if ua_data.device
+    ua = ua_data.userAgent
+    event.set(@name_field, duped_string(ua.family))
+    event.set(@device_name_field, duped_string(ua_data.device)) if ua_data.device
+
+    event.set(@major_field, duped_string(ua.major)) if ua.major
+    event.set(@minor_field, duped_string(ua.minor)) if ua.minor
+    event.set(@patch_field, duped_string(ua.patch)) if ua.patch
+    set_version(event, ua_source, ua) # UA version string e.g. "89.0.4389.90"
 
     os = ua_data.os
     if os
-      # The OS is a rich object
-      event.set(@prefixed_os, duped_string(os.family))
-      event.set(@prefixed_os_name, duped_string(os.family)) if os.family
+      # os.major, os.minor, ... are all strings
+      event.set(@os_major_field, duped_string(os.major)) if os.major # e.g. 'Vista' or '10'
+      event.set(@os_minor_field, duped_string(os.minor)) if os.minor
+      event.set(@os_patch_field, duped_string(os.patch)) if os.patch
+      os_version = build_os_version(os)
+      verified_os_version = check_and_adjust_version(ua_source, os_version)
+      # only set OS version if it's not 'interpreted' (contained in UA string)
+      event.set(@os_version_field, verified_os_version) if verified_os_version
 
-      # These are all strings
-      major, minor = os.major, os.minor
-      event.set(@prefixed_os_major, duped_string(major)) if major # e.g. 'Vista' or '10'
-      event.set(@prefixed_os_minor, duped_string(minor)) if minor
+      os_name = os.family
+      if os_name
+        os_name = duped_string(os_name)
+        event.set(@os_name_field, os_name)
+        os_full_name = os_name.dup
+        os_full_name << ' ' << os_version if os_version
+        event.set(@os_full_name_field, os_full_name)
+      end
     end
+  end
 
-    ua_version = ua_data.userAgent
-    if ua_version
-      event.set(@prefixed_major, duped_string(ua_version.major)) if ua_version.major
-      event.set(@prefixed_minor, duped_string(ua_version.minor)) if ua_version.minor
-      event.set(@prefixed_patch, duped_string(ua_version.patch)) if ua_version.patch
+  # reconstruct and set the User-Agent version string
+  def set_version(event, ua_source, ua)
+    if @version_field && ua.major
+      # only Chrome has all 4 segments, while Firefox only uses major.minor
+      version = duped_string(ua.major)
+      if ua.minor
+        version << '.' << ua.minor
+        if ua.patch
+          version << '.' << ua.patch
+          if ua.patchMinor
+            version << '.' << ua.patchMinor
+          else
+            adjusted_version = check_and_adjust_version(ua_source, version)
+            version = adjusted_version if adjusted_version
+          end
+        end
+      end
+      event.set(@version_field, version)
     end
+  end
+
+  def check_and_adjust_version(ua_source, version)
+    # only set OS version if it's not 'interpreted' (contained in UA string)
+    return nil if !version || (i = ua_source.index(version)).nil?
+    i += version.size
+    # complete version when patchMinor is not matched but still there
+    if ua_source[i] == '.' # we built the version with dots
+      if patch_minor = ua_source.index(' ', i + 1)
+        patch_minor = ua_source[i + 1...patch_minor]
+        if patch_minor.eql? patch_minor.to_i.to_s
+          version = "#{version}.#{patch_minor}"
+        end
+      end
+    end
+    version
+  end
+
+  # reconstructs the OS version string
+  def build_os_version(os)
+    # NOTE: UA regexes don't always give us the versions back
+    # they do get "corrected" for various OSes such as:
+    # - Windows (Windows NT 6.0 => 'Vista')
+    # - Windows ('Windows NT 6.3' => '8','1')
+    # - Windows ('Windows NT 10.0' => '10')
+    # - iOS ('Darwin/15.5' => '9','3','2')
+    return unless major = os.major
+    if major.to_i.to_s == major
+      version, sep = duped_string(major), '.'
+    else
+      version, sep = duped_string(major), ' '
+    end
+    if os.minor
+      version << sep << os.minor
+      if os.patch
+        version << '.' << os.patch
+        if os.patchMinor
+          version << '.' << os.patchMinor
+        end
+      end
+    end
+    version
   end
 
   def duped_string(str)

--- a/lib/logstash/filters/useragent.rb
+++ b/lib/logstash/filters/useragent.rb
@@ -74,11 +74,12 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
     @minor_field = ecs_select[disabled: "#{target}[#{@prefix}minor]", v1: "[@metadata][filter][user_agent][version][minor]"]
     @patch_field = ecs_select[disabled: "#{target}[#{@prefix}patch]", v1: "[@metadata][filter][user_agent][version][patch]"]
 
-    @os_full_name_field = ecs_select[disabled: "[#{@prefix}os]", v1: '[os][full]']
+    @os_full_name_field = ecs_select[disabled: "[#{@prefix}os_full]", v1: '[os][full]'] # did not exist in legacy prior to ECS-ification
     @os_full_name_field = "#{target}#{@os_full_name_field}"
 
-    @os_name_field = ecs_select[disabled:"[#{@prefix}os_name]", v1: '[os][name]']
+    @os_name_field = ecs_select[disabled: "[#{@prefix}os_name]", v1: '[os][name]']
     @os_name_field = "#{target}#{@os_name_field}"
+    @legacy_os_field = ecs_select[disabled: "#{target}[#{@prefix}os]", v1: nil] # same as [os_name] in legacy mode
 
     @os_version_field = ecs_select[disabled: "[#{@prefix}os_version]", v1: '[os][version]']
     @os_version_field = "#{target}#{@os_version_field}"
@@ -157,6 +158,7 @@ class LogStash::Filters::UserAgent < LogStash::Filters::Base
       if os_name
         os_name = duped_string(os_name)
         event.set(@os_name_field, os_name)
+        event.set(@legacy_os_field, os_name.dup) if @legacy_os_field
         os_full_name = os_name.dup
         os_full_name << ' ' << os_version if os_version
         event.set(@os_full_name_field, os_full_name)

--- a/logstash-filter-useragent.gemspec
+++ b/logstash-filter-useragent.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.1'
   s.add_development_dependency 'logstash-devutils'
 end
 

--- a/spec/filters/useragent_spec.rb
+++ b/spec/filters/useragent_spec.rb
@@ -203,7 +203,9 @@ describe LogStash::Filters::UserAgent do
           expect( subject.get("[ua][version]") ).to eql "89.0.774.50"
           expect( subject.get("[ua][os][full]") ).to eql "Windows 10"
           expect( subject.get("[ua][os][name]") ).to eql "Windows"
-          expect( subject.get("[ua][os][version]") ).to be nil
+          # NOTE: not really matching ECS requirement to be the original '10.0'
+          # tested ES 7.10 user_agent processor and it returns '10' as well
+          expect( subject.get("[ua][os][version]") ).to eql '10'
           ua_metadata = subject.get("[@metadata][filter][user_agent][os]")
           expect( ua_metadata ).to include 'version' => { 'major' => '10' }
           expect( subject.get("[ua][device][name]") ).to eql 'Other'

--- a/spec/filters/useragent_spec.rb
+++ b/spec/filters/useragent_spec.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
+require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
 require "logstash/filters/useragent"
 
 describe LogStash::Filters::UserAgent do
@@ -8,205 +9,371 @@ describe LogStash::Filters::UserAgent do
 
   let(:options) { { "source" => "foo" } }
 
-  describe "defaults" do
-    config <<-CONFIG
-      filter {
-        useragent {
-          source => "message"
-          target => "ua"
+  context 'with target', :ecs_compatibility_support do
+    ecs_compatibility_matrix(:disabled, :v1) do |ecs_select|
+
+      let(:ecs_compatibility?) { ecs_select.active_mode != :disabled }
+
+      before(:each) do
+        allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)
+      end
+
+      config <<-CONFIG
+        filter {
+          useragent {
+            source => "message"
+            target => "ua"
+          }
         }
-      }
-    CONFIG
+      CONFIG
 
-    sample "Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.63 Safari/537.31" do
-      expect( subject.to_hash ).to include("ua")
-      expect( subject.get("[ua][name]") ).to eql "Chrome"
-      expect( subject.get("[ua][os]") ).to eql "Linux"
-      expect( subject.get("[ua][major]") ).to eql "26"
-      expect( subject.get("[ua][minor]") ).to eql "0"
-      expect( subject.get("[ua][device]") ).to eql "Other"
+      sample "Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.63 Safari/537.31" do
+        expect( subject.to_hash ).to include("ua")
+        expect( subject.get("[ua][name]") ).to eql "Chrome"
+        if ecs_compatibility?
+          expect( subject.get("[ua][os][name]") ).to eql "Linux"
+          expect( subject.get("[ua][os][full]") ).to eql "Linux"
+          expect( subject.get("[ua][device][name]") ).to eql "Other"
+          ua_metadata = subject.get("[@metadata][filter][user_agent]")
+          expect( ua_metadata ).to include 'version' => { 'major' => '26', 'minor' => '0', 'patch' => '1410' }
+          expect( subject.get("[ua][version]") ).to eql "26.0.1410.63"
+          expect( subject.get("[ua]").keys ).to_not include 'major'
+          expect( subject.get("[ua]").keys ).to_not include 'minor'
+        else
+          expect( subject.get("[ua][os_name]") ).to eql "Linux"
+          expect( subject.get("[ua][os]") ).to eql "Linux"
+          expect( subject.get("[ua][device]") ).to eql "Other"
+          expect( subject.get("[ua][major]") ).to eql "26"
+          expect( subject.get("[ua][minor]") ).to eql "0"
+        end
 
-      expect( subject.get("[ua][minor]").encoding ).to eql Encoding::UTF_8
-    end
+        expect( subject.get("[ua][name]").encoding ).to eql Encoding::UTF_8
+      end
 
-    sample "MacOutlook/16.24.0.190414 (Intelx64 Mac OS X Version 10.14.4 (Build 18E226))" do
-      expect( subject.to_hash ).to include("ua")
-      expect( subject.get("[ua][name]") ).to eql "MacOutlook"
-      expect( subject.get("[ua][major]") ).to eql "16"
-      expect( subject.get("[ua][minor]") ).to eql "24"
-      expect( subject.get("[ua][patch]") ).to eql "0"
-      expect( subject.get("[ua][os]") ).to eql "Mac OS X"
-      expect( subject.get("[ua][os_name]") ).to eql "Mac OS X"
-      expect( subject.get("[ua][os_major]") ).to eql '10'
-      expect( subject.get("[ua][os_minor]") ).to eql '14'
-      expect( subject.get("[ua][device]") ).to eql 'Mac'
+      sample "MacOutlook/16.24.0.190414 (Intelx64 Mac OS X Version 10.14.4 (Build 18E226))" do
+        expect( subject.to_hash ).to include("ua")
+        expect( subject.get("[ua][name]") ).to eql "MacOutlook"
+        if ecs_compatibility?
+          expect( subject.get("[ua][version]") ).to eql "16.24.0.190414"
+          expect( subject.get("[ua][os][full]") ).to eql "Mac OS X 10.14.4"
+          expect( subject.get("[ua][os][name]") ).to eql "Mac OS X"
+          expect( subject.get("[ua][os][version]") ).to eql '10.14.4'
+          expect( subject.get("[ua][device][name]") ).to eql 'Mac'
 
-      expect( subject.get("[ua][os_major]").encoding ).to eql Encoding::UTF_8
-    end
+          expect( subject.get("[ua][os][name]").encoding ).to eql Encoding::UTF_8
+        else
+          expect( subject.get("[ua][major]") ).to eql "16"
+          expect( subject.get("[ua][minor]") ).to eql "24"
+          expect( subject.get("[ua][patch]") ).to eql "0"
+          expect( subject.get("[ua][os]") ).to eql "Mac OS X 10.14.4"
+          expect( subject.get("[ua][os_name]") ).to eql "Mac OS X"
+          expect( subject.get("[ua][os_major]") ).to eql '10'
+          expect( subject.get("[ua][os_minor]") ).to eql '14'
+          expect( subject.get("[ua][device]") ).to eql 'Mac'
 
-    # Safari 12 on Mojave
-    sample "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15" do
-      expect( subject.to_hash ).to include("ua")
-      expect( subject.get("[ua][name]") ).to eql "Safari"
-      expect( subject.get("[ua][major]") ).to eql "12"
-      expect( subject.get("[ua][minor]") ).to eql "0"
-      expect( subject.get("[ua][patch]") ).to be nil
-      expect( subject.get("[ua][os]") ).to eql "Mac OS X"
-      expect( subject.get("[ua][os_major]") ).to eql '10'
-      expect( subject.get("[ua][os_minor]") ).to eql '14'
-    end
+          expect( subject.get("[ua][os]").encoding ).to eql Encoding::UTF_8
+        end
+      end
 
-    # Safari 7 on Mac OS X (Mavericks)
-    sample "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A" do
-      expect( subject.to_hash ).to include("ua")
-      expect( subject.get("[ua][name]") ).to eql "Safari"
-      expect( subject.get("[ua][major]") ).to eql "7"
-      expect( subject.get("[ua][minor]") ).to eql "0"
-      expect( subject.get("[ua][patch]") ).to eql "3"
-      expect( subject.get("[ua][os]") ).to eql "Mac OS X"
-      expect( subject.get("[ua][os_major]") ).to eql '10'
-      expect( subject.get("[ua][os_minor]") ).to eql '9'
-      expect( subject.get("[ua][device]") ).to eql 'Mac'
-    end
+      # Safari 12 on Mojave
+      sample "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15" do
+        expect( subject.to_hash ).to include("ua")
+        expect( subject.get("[ua][name]") ).to eql "Safari"
+        if ecs_compatibility?
+          expect( subject.get("[ua][version]") ).to eql "12.0"
+          expect( subject.get("[ua][os][full]") ).to eql "Mac OS X 10.14"
+          expect( subject.get("[ua][os][name]") ).to eql "Mac OS X"
+          expect( subject.get("[ua][os][version]") ).to be nil # we reconstruct using '.' but UA contains '10_14'
+          ua_metadata = subject.get("[@metadata][filter][user_agent][os]")
+          expect( ua_metadata ).to include 'version' => { 'major' => '10', 'minor' => '14' }
 
-    sample "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:45.0) Gecko/20100101 Firefox/45.0" do
-      expect( subject.to_hash ).to include("ua")
-      expect( subject.get("[ua][name]") ).to eql "Firefox"
-      expect( subject.get("[ua][major]") ).to eql "45"
-      expect( subject.get("[ua][minor]") ).to eql "0"
-      expect( subject.get("[ua][patch]") ).to be nil
-      expect( subject.get("[ua][os]") ).to eql "Mac OS X"
-      expect( subject.get("[ua][os_major]") ).to eql '10'
-      expect( subject.get("[ua][os_minor]") ).to eql '11'
-      expect( subject.get("[ua][device]") ).to eql 'Mac'
-    end
+          expect( subject.get("[@metadata][filter][user_agent][os][version][major]").encoding ).to eql Encoding::UTF_8
+        else
+          expect( subject.get("[ua][major]") ).to eql "12"
+          expect( subject.get("[ua][minor]") ).to eql "0"
+          expect( subject.get("[ua][patch]") ).to be nil
+          expect( subject.get("[ua][os]") ).to eql "Mac OS X 10.14"
+          expect( subject.get("[ua][os_name]") ).to eql "Mac OS X"
+          expect( subject.get("[ua][os_major]") ).to eql '10'
+          expect( subject.get("[ua][os_minor]") ).to eql '14'
 
-    # IE7 Vista
-    sample "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)" do
-      expect( subject.to_hash ).to include("ua")
-      expect( subject.get("[ua][os]") ).to eql "Windows"
-      expect( subject.get("[ua][os_major]") ).to eql 'Vista'
-      expect( subject.get("[ua][os_minor]") ).to be nil
-      expect( subject.get("[ua][device]") ).to eql 'Other'
+          expect( subject.get("[ua][os_major]").encoding ).to eql Encoding::UTF_8
+        end
+      end
 
-      expect( subject.get("[ua][device]").encoding ).to eql Encoding::UTF_8
-    end
+      # Safari 7 on Mac OS X (Mavericks)
+      sample "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A" do
+        expect( subject.to_hash ).to include("ua")
+        expect( subject.get("[ua][name]") ).to eql "Safari"
+        if ecs_compatibility?
+          expect( subject.get("[ua][version]") ).to eql "7.0.3"
+          expect( subject.get("[ua][os][full]") ).to eql "Mac OS X 10.9.3"
+          expect( subject.get("[ua][os][name]") ).to eql "Mac OS X"
+          expect( subject.get("[ua][device][name]") ).to eql 'Mac'
+        else
+          expect( subject.get("[ua][major]") ).to eql "7"
+          expect( subject.get("[ua][minor]") ).to eql "0"
+          expect( subject.get("[ua][patch]") ).to eql "3"
+          expect( subject.get("[ua][os]") ).to eql "Mac OS X 10.9.3"
+          expect( subject.get("[ua][os_name]") ).to eql "Mac OS X"
+          expect( subject.get("[ua][os_major]") ).to eql '10'
+          expect( subject.get("[ua][os_minor]") ).to eql '9'
+          expect( subject.get("[ua][device]") ).to eql 'Mac'
+        end
+      end
 
-    # IE8 XP
-    sample "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.5.30729)" do
-      expect( subject.to_hash ).to include("ua")
-      expect( subject.get("[ua][os]") ).to eql 'Windows'
-      expect( subject.get("[ua][os_major]") ).to eql 'XP'
-      expect( subject.get("[ua][os_minor]") ).to be nil
-      expect( subject.get("[ua][name]") ).to eql 'IE'
-      expect( subject.get("[ua][device]") ).to eql 'Other'
-    end
+      sample "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:45.0) Gecko/20100101 Firefox/45.0" do
+        expect( subject.to_hash ).to include("ua")
+        expect( subject.get("[ua][name]") ).to eql "Firefox"
+        if ecs_compatibility?
+          expect( subject.get("[ua][version]") ).to eql "45.0"
+          expect( subject.get("[ua][os][full]") ).to eql "Mac OS X 10.11"
+          expect( subject.get("[ua][os][name]") ).to eql "Mac OS X"
+          expect( subject.get("[ua][os][version]") ).to eql '10.11'
+          expect( subject.get("[ua][device][name]") ).to eql 'Mac'
+        else
+          expect( subject.get("[ua][major]") ).to eql "45"
+          expect( subject.get("[ua][minor]") ).to eql "0"
+          expect( subject.get("[ua][patch]") ).to be nil
+          expect( subject.get("[ua][os]") ).to eql "Mac OS X 10.11"
+          expect( subject.get("[ua][os_name]") ).to eql "Mac OS X"
+          expect( subject.get("[ua][os_major]") ).to eql '10'
+          expect( subject.get("[ua][os_minor]") ).to eql '11'
+          expect( subject.get("[ua][device]") ).to eql 'Mac'
+        end
+      end
 
-    # Windows 8.1
-    sample "Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246" do
-      expect( subject.to_hash ).to include("ua")
-      expect( subject.get("[ua][os]") ).to eql 'Windows'
-      expect( subject.get("[ua][os_major]") ).to eql '8'
-      expect( subject.get("[ua][os_minor]") ).to eql '1'
-      expect( subject.get("[ua][name]") ).to eql 'Edge'
-      expect( subject.get("[ua][device]") ).to eql 'Other'
-    end
+      # IE7 Vista
+      sample "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)" do
+        expect( subject.to_hash ).to include("ua")
+        if ecs_compatibility?
+          expect( subject.get("[ua][os][name]") ).to eql "Windows"
+          expect( subject.get("[ua][os][version]") ).to be nil
+          expect( subject.get("[ua][device][name]") ).to eql 'Other'
 
-    # Windows 10
-    sample "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36 Edg/89.0.774.50" do
-      expect( subject.to_hash ).to include("ua")
-      expect( subject.get("[ua][os]") ).to eql "Windows"
-      expect( subject.get("[ua][os_major]") ).to eql '10'
-      expect( subject.get("[ua][os_minor]") ).to be nil
-      expect( subject.get("[ua][name]") ).to eql 'Edge'
-      expect( subject.get("[ua][device]") ).to eql 'Other'
-    end
+          expect( subject.get("[ua][device][name]").encoding ).to eql Encoding::UTF_8
+        else
+          expect( subject.get("[ua][os_name]") ).to eql "Windows"
+          expect( subject.get("[ua][os_major]") ).to eql 'Vista'
+          expect( subject.get("[ua][os_minor]") ).to be nil
+          expect( subject.get("[ua][device]") ).to eql 'Other'
 
-    # Chrome on Linux
-    sample "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" do
-      expect( subject.to_hash ).to include("ua")
-      expect( subject.get("[ua][os]") ).to eql "Linux"
-      expect( subject.get("[ua][os_major]") ).to be nil
-      expect( subject.get("[ua][os_minor]") ).to be nil
-      expect( subject.get("[ua][name]") ).to eql 'Chrome'
-      expect( subject.get("[ua][device]") ).to eql 'Other'
+          expect( subject.get("[ua][device]").encoding ).to eql Encoding::UTF_8
+        end
+      end
+
+      # IE8 XP
+      sample "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.5.30729)" do
+        expect( subject.to_hash ).to include("ua")
+        expect( subject.get("[ua][name]") ).to eql 'IE'
+        if ecs_compatibility?
+          expect( subject.get("[ua][os][name]") ).to eql 'Windows'
+          expect( subject.get("[ua][os][version]") ).to be nil
+          expect( subject.get("[ua][device][name]") ).to eql 'Other'
+        else
+          expect( subject.get("[ua][os_name]") ).to eql 'Windows'
+          expect( subject.get("[ua][os_major]") ).to eql 'XP'
+          expect( subject.get("[ua][os_minor]") ).to be nil
+          expect( subject.get("[ua][device]") ).to eql 'Other'
+        end
+      end
+
+      # # Windows 8.1
+      sample "Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246" do
+        expect( subject.to_hash ).to include("ua")
+        expect( subject.get("[ua][name]") ).to eql 'Edge'
+        if ecs_compatibility?
+          expect( subject.get("[ua][os][name]") ).to eql 'Windows'
+          expect( subject.get("[ua][os][version]") ).to be nil # should be '6.3'
+        else
+          expect( subject.get("[ua][os_name]") ).to eql 'Windows'
+          expect( subject.get("[ua][os_major]") ).to eql '8'
+          expect( subject.get("[ua][os_minor]") ).to eql '1'
+        end
+      end
+
+      # Windows 10
+      sample "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36 Edg/89.0.774.50" do
+        expect( subject.to_hash ).to include("ua")
+        expect( subject.get("[ua][name]") ).to eql "Edge"
+        if ecs_compatibility?
+          expect( subject.get("[ua][version]") ).to eql "89.0.774.50"
+          expect( subject.get("[ua][os][full]") ).to eql "Windows 10"
+          expect( subject.get("[ua][os][name]") ).to eql "Windows"
+          expect( subject.get("[ua][os][version]") ).to be nil
+          ua_metadata = subject.get("[@metadata][filter][user_agent][os]")
+          expect( ua_metadata ).to include 'version' => { 'major' => '10' }
+          expect( subject.get("[ua][device][name]") ).to eql 'Other'
+        else
+          expect( subject.get("[ua][os_name]") ).to eql "Windows"
+          expect( subject.get("[ua][os_major]") ).to eql '10'
+          expect( subject.get("[ua][os_minor]") ).to be nil
+          expect( subject.get("[ua][device]") ).to eql 'Other'
+        end
+      end
+
+      # Chrome on Linux
+      sample "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" do
+        expect( subject.to_hash ).to include("ua")
+        expect( subject.get("[ua][name]") ).to eql 'Chrome'
+        if ecs_compatibility?
+          expect( subject.get("[ua][os][name]") ).to eql "Linux"
+          expect( subject.get("[ua][os][version]") ).to be nil
+          expect( subject.get("[ua][device][name]") ).to eql 'Other'
+        else
+          expect( subject.get("[ua][os_name]") ).to eql "Linux"
+          expect( subject.get("[ua][os_major]") ).to be nil
+          expect( subject.get("[ua][os_minor]") ).to be nil
+          expect( subject.get("[ua][device]") ).to eql 'Other'
+        end
+      end
+
     end
   end
 
-  describe "manually specified regexes file" do
-    config <<-CONFIG
-      filter {
-        useragent {
-          source => "message"
-          target => "[ua]"
-          regexes => "build/resources/main/regexes.yaml"
+  context "manually specified regexes file", :ecs_compatibility_support do
+    ecs_compatibility_matrix(:disabled, :v1) do |ecs_select|
+
+      let(:ecs_compatibility?) { ecs_select.active_mode != :disabled }
+
+      before(:each) do
+        allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)
+      end
+
+      config <<-CONFIG
+        filter {
+          useragent {
+            source => "message"
+            target => "[ua]"
+            regexes => "build/resources/main/regexes.yaml"
+          }
         }
-      }
-    CONFIG
+      CONFIG
 
-    sample "Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.63 Safari/537.31" do
-      expect( subject.to_hash ).to include("ua")
-      expect( subject.get("[ua][name]") ).to eql "Chrome"
-      expect( subject.get("[ua][os]") ).to eql "Linux"
-      expect( subject.get("[ua][major]") ).to eql "26"
-      expect( subject.get("[ua][minor]") ).to eql "0"
-    end
-  end
-  
-  describe "Without target field" do
-    config <<-CONFIG
-      filter {
-        useragent {
-          source => "message"
-        }
-      }
-    CONFIG
+      sample "Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.63 Safari/537.31" do
+        expect( subject.to_hash ).to include("ua")
+        if ecs_compatibility?
+          expect( subject.get("[ua][name]") ).to eql "Chrome"
+          expect( subject.get("[ua][os][name]") ).to eql "Linux"
+          expect( subject.get("[ua][version]") ).to eql "26.0.1410.63"
+          expect( subject.get("[@metadata][filter][user_agent][version][major]") ).to eql "26"
+          expect( subject.get("[@metadata][filter][user_agent][version][minor]") ).to eql "0"
+        else
+          expect( subject.get("[ua][name]") ).to eql "Chrome"
+          expect( subject.get("[ua][os]") ).to eql "Linux"
+          expect( subject.get("[ua][major]") ).to eql "26"
+          expect( subject.get("[ua][minor]") ).to eql "0"
+        end
+      end
 
-    sample "Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.63 Safari/537.31" do
-      expect( subject.get("name") ).to eql "Chrome"
-      expect( subject.get("os") ).to eql "Linux"
-      expect( subject.get("major") ).to eql "26"
-      expect( subject.get("minor") ).to eql "0"
-      expect( subject.get("patch") ).to eql "1410"
-    end
-  end
-
-  describe "nested target field" do
-    config <<-CONFIG
-      filter {
-        useragent {
-          source => "message"
-          target => "[foo][bar]"
-        }
-      }
-    CONFIG
-
-    # Facebook App User Agent
-    sample "Mozilla/5.0 (iPhone; CPU iPhone OS 13_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) " +
-           "Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone11,8;FBMD/iPhone;FBSN/iOS;FBSV/13.3.1;FBSS/2;FBID/phone;FBLC/en_US;FBOP/5;FBCR/]" do
-      expect( subject ).to include 'foo'
-      expect( subject.get('foo') ).to include 'bar'
-      expect( subject.get('foo')['bar'] ).to include "name" => "Facebook", "device" => "iPhone", "os" => "iOS"
     end
   end
 
-  describe "Without user agent" do
+  context "without target field", :ecs_compatibility_support do
+    ecs_compatibility_matrix(:disabled, :v1) do |ecs_select|
+
+      let(:ecs_compatibility?) { ecs_select.active_mode != :disabled }
+
+      before(:each) do
+        allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)
+      end
+
+      config <<-CONFIG
+        filter {
+          useragent {
+            source => "message"
+          }
+        }
+      CONFIG
+
+      sample "Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.63 Safari/537.31" do
+        if ecs_compatibility?
+          expect( subject.get("user_agent") ).to include 'name' => 'Chrome'
+          expect( subject.get("user_agent") ).to include 'os' => hash_including('name' => 'Linux')
+          expect( subject.get("user_agent") ).to include 'version' => '26.0.1410.63'
+        else
+          expect( subject.get("name") ).to eql "Chrome"
+          expect( subject.get("os") ).to eql "Linux"
+          expect( subject.get("major") ).to eql "26"
+          expect( subject.get("minor") ).to eql "0"
+          expect( subject.get("patch") ).to eql "1410"
+          expect( subject.get("version") ).to eql "26.0.1410.63"
+        end
+      end
+    end
+  end
+
+  context "nested target field", :ecs_compatibility_support do
+    ecs_compatibility_matrix(:disabled, :v1) do
+
+      before(:each) do
+        allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)
+      end
+
+      config <<-CONFIG
+        filter {
+          useragent {
+            source => "message"
+            target => "[foo][bar]"
+          }
+        }
+      CONFIG
+
+      # Facebook App User Agent
+      sample "Mozilla/5.0 (iPhone; CPU iPhone OS 13_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) " +
+             "Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone11,8;FBMD/iPhone;FBSN/iOS;FBSV/13.3.1;FBSS/2;FBID/phone;FBLC/en_US;FBOP/5;FBCR/]" do
+        expect( subject ).to include 'foo'
+        expect( subject.get('foo') ).to include 'bar'
+        expect( subject.get('foo')['bar'] ).to include "name" => "Facebook"
+      end
+
+    end
+  end
+
+  context "without user agent", :ecs_compatibility_support do
+    ecs_compatibility_matrix(:disabled, :v1) do |ecs_select|
+
+      let(:ecs_compatibility?) { ecs_select.active_mode != :disabled }
+
+      before(:each) do
+        allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)
+      end
+
+      config <<-CONFIG
+        filter {
+          useragent {
+            source => "message"
+            target => "ua"
+          }
+        }
+      CONFIG
+
+      sample "foo" => "bar" do
+        expect( subject.to_hash ).to_not include("ua")
+      end
+
+      sample "" do
+        expect( subject.to_hash ).to_not include("ua")
+      end
+
+    end
+  end
+
+  describe "non-exact UA data" do
     config <<-CONFIG
       filter {
         useragent {
           source => "message"
-          target => "ua"
+          target => "user_agent"
         }
       }
     CONFIG
 
-    sample "foo" => "bar" do
-      expect( subject.to_hash ).to_not include("ua")
+    sample 'Prefix DATA! Mozilla/5.0 (Android 11; Mobile; rv:68.0) Gecko/68.0 Firefox/86.0' do
+      expect( subject.to_hash ).to include("user_agent")
+      expect( subject.get('user_agent') ).to include "name" => "Firefox Mobile", "version" => '86.0', "os_name" => "Android"
     end
 
-    sample "" do
-      expect( subject.to_hash ).to_not include("ua")
-    end
   end
 
   let(:ua_string) { "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.85 Safari/537.36" }
@@ -227,7 +394,6 @@ describe LogStash::Filters::UserAgent do
 
     {
       "name" => lambda {|uad| uad.userAgent.family},
-      "os" => lambda {|uad| uad.os.family},
       "os_name" => lambda {|uad| uad.os.family},
       "os_major" => lambda {|uad| uad.os.major},
       "os_minor" => lambda {|uad| uad.os.minor},

--- a/spec/filters/useragent_spec.rb
+++ b/spec/filters/useragent_spec.rb
@@ -86,6 +86,7 @@ describe LogStash::Filters::UserAgent do
           expect( subject.get("[ua][version]") ).to eql "12.0"
           expect( subject.get("[ua][os][full]") ).to eql "Mac OS X 10.14"
           expect( subject.get("[ua][os][name]") ).to eql "Mac OS X"
+          # TODO ES' user_agent processor fills os.version as '10.14'
           expect( subject.get("[ua][os][version]") ).to be nil # we reconstruct using '.' but UA contains '10_14'
           ua_metadata = subject.get("[@metadata][filter][user_agent][os]")
           expect( ua_metadata ).to include 'version' => { 'major' => '10', 'minor' => '14' }
@@ -171,6 +172,7 @@ describe LogStash::Filters::UserAgent do
         expect( subject.get("[ua][name]") ).to eql 'IE'
         if ecs_compatibility?
           expect( subject.get("[ua][os][name]") ).to eql 'Windows'
+          # NOTE: ES' user_agent fills in os.version as 'XP'
           expect( subject.get("[ua][os][version]") ).to be nil
           expect( subject.get("[ua][device][name]") ).to eql 'Other'
         else
@@ -187,6 +189,7 @@ describe LogStash::Filters::UserAgent do
         expect( subject.get("[ua][name]") ).to eql 'Edge'
         if ecs_compatibility?
           expect( subject.get("[ua][os][name]") ).to eql 'Windows'
+          # TODO ES' user_agent processor fills os.version as '8.1'
           expect( subject.get("[ua][os][version]") ).to be nil # should be '6.3'
         else
           expect( subject.get("[ua][os_name]") ).to eql 'Windows'

--- a/spec/filters/useragent_spec.rb
+++ b/spec/filters/useragent_spec.rb
@@ -44,6 +44,7 @@ describe LogStash::Filters::UserAgent do
           expect( subject.get("[ua]").keys ).to_not include 'minor'
         else
           expect( subject.get("[ua][os_name]") ).to eql "Linux"
+          expect( subject.get("[ua][os_full]") ).to eql "Linux"
           expect( subject.get("[ua][os]") ).to eql "Linux"
           expect( subject.get("[ua][device]") ).to eql "Other"
           expect( subject.get("[ua][major]") ).to eql "26"
@@ -68,12 +69,13 @@ describe LogStash::Filters::UserAgent do
           expect( subject.get("[ua][major]") ).to eql "16"
           expect( subject.get("[ua][minor]") ).to eql "24"
           expect( subject.get("[ua][patch]") ).to eql "0"
-          expect( subject.get("[ua][os]") ).to eql "Mac OS X 10.14.4"
+          expect( subject.get("[ua][os_full]") ).to eql "Mac OS X 10.14.4"
           expect( subject.get("[ua][os_name]") ).to eql "Mac OS X"
           expect( subject.get("[ua][os_major]") ).to eql '10'
           expect( subject.get("[ua][os_minor]") ).to eql '14'
           expect( subject.get("[ua][device]") ).to eql 'Mac'
 
+          expect( subject.get("[ua][os]") ).to eql "Mac OS X"
           expect( subject.get("[ua][os]").encoding ).to eql Encoding::UTF_8
         end
       end
@@ -95,7 +97,7 @@ describe LogStash::Filters::UserAgent do
           expect( subject.get("[ua][major]") ).to eql "12"
           expect( subject.get("[ua][minor]") ).to eql "0"
           expect( subject.get("[ua][patch]") ).to be nil
-          expect( subject.get("[ua][os]") ).to eql "Mac OS X 10.14"
+          expect( subject.get("[ua][os_full]") ).to eql "Mac OS X 10.14"
           expect( subject.get("[ua][os_name]") ).to eql "Mac OS X"
           expect( subject.get("[ua][os_major]") ).to eql '10'
           expect( subject.get("[ua][os_minor]") ).to eql '14'
@@ -117,7 +119,7 @@ describe LogStash::Filters::UserAgent do
           expect( subject.get("[ua][major]") ).to eql "7"
           expect( subject.get("[ua][minor]") ).to eql "0"
           expect( subject.get("[ua][patch]") ).to eql "3"
-          expect( subject.get("[ua][os]") ).to eql "Mac OS X 10.9.3"
+          expect( subject.get("[ua][os_full]") ).to eql "Mac OS X 10.9.3"
           expect( subject.get("[ua][os_name]") ).to eql "Mac OS X"
           expect( subject.get("[ua][os_major]") ).to eql '10'
           expect( subject.get("[ua][os_minor]") ).to eql '9'
@@ -138,7 +140,7 @@ describe LogStash::Filters::UserAgent do
           expect( subject.get("[ua][major]") ).to eql "45"
           expect( subject.get("[ua][minor]") ).to eql "0"
           expect( subject.get("[ua][patch]") ).to be nil
-          expect( subject.get("[ua][os]") ).to eql "Mac OS X 10.11"
+          expect( subject.get("[ua][os_full]") ).to eql "Mac OS X 10.11"
           expect( subject.get("[ua][os_name]") ).to eql "Mac OS X"
           expect( subject.get("[ua][os_major]") ).to eql '10'
           expect( subject.get("[ua][os_minor]") ).to eql '11'
@@ -296,6 +298,7 @@ describe LogStash::Filters::UserAgent do
           expect( subject.get("user_agent") ).to include 'version' => '26.0.1410.63'
         else
           expect( subject.get("name") ).to eql "Chrome"
+          expect( subject.get("os_name") ).to eql "Linux"
           expect( subject.get("os") ).to eql "Linux"
           expect( subject.get("major") ).to eql "26"
           expect( subject.get("minor") ).to eql "0"

--- a/spec/filters/useragent_spec.rb
+++ b/spec/filters/useragent_spec.rb
@@ -86,8 +86,7 @@ describe LogStash::Filters::UserAgent do
           expect( subject.get("[ua][version]") ).to eql "12.0"
           expect( subject.get("[ua][os][full]") ).to eql "Mac OS X 10.14"
           expect( subject.get("[ua][os][name]") ).to eql "Mac OS X"
-          # TODO ES' user_agent processor fills os.version as '10.14'
-          expect( subject.get("[ua][os][version]") ).to be nil # we reconstruct using '.' but UA contains '10_14'
+          expect( subject.get("[ua][os][version]") ).to eql '10.14'
           ua_metadata = subject.get("[@metadata][filter][user_agent][os]")
           expect( ua_metadata ).to include 'version' => { 'major' => '10', 'minor' => '14' }
 
@@ -152,7 +151,7 @@ describe LogStash::Filters::UserAgent do
         expect( subject.to_hash ).to include("ua")
         if ecs_compatibility?
           expect( subject.get("[ua][os][name]") ).to eql "Windows"
-          expect( subject.get("[ua][os][version]") ).to be nil
+          expect( subject.get("[ua][os][version]") ).to eql 'Vista'
           expect( subject.get("[ua][device][name]") ).to eql 'Other'
 
           expect( subject.get("[ua][device][name]").encoding ).to eql Encoding::UTF_8
@@ -172,8 +171,7 @@ describe LogStash::Filters::UserAgent do
         expect( subject.get("[ua][name]") ).to eql 'IE'
         if ecs_compatibility?
           expect( subject.get("[ua][os][name]") ).to eql 'Windows'
-          # NOTE: ES' user_agent fills in os.version as 'XP'
-          expect( subject.get("[ua][os][version]") ).to be nil
+          expect( subject.get("[ua][os][version]") ).to eql 'XP'
           expect( subject.get("[ua][device][name]") ).to eql 'Other'
         else
           expect( subject.get("[ua][os_name]") ).to eql 'Windows'
@@ -189,8 +187,7 @@ describe LogStash::Filters::UserAgent do
         expect( subject.get("[ua][name]") ).to eql 'Edge'
         if ecs_compatibility?
           expect( subject.get("[ua][os][name]") ).to eql 'Windows'
-          # TODO ES' user_agent processor fills os.version as '8.1'
-          expect( subject.get("[ua][os][version]") ).to be nil # should be '6.3'
+          expect( subject.get("[ua][os][version]") ).to eql '8.1'
         else
           expect( subject.get("[ua][os_name]") ).to eql 'Windows'
           expect( subject.get("[ua][os_major]") ).to eql '8'
@@ -206,8 +203,6 @@ describe LogStash::Filters::UserAgent do
           expect( subject.get("[ua][version]") ).to eql "89.0.774.50"
           expect( subject.get("[ua][os][full]") ).to eql "Windows 10"
           expect( subject.get("[ua][os][name]") ).to eql "Windows"
-          # NOTE: not really matching ECS requirement to be the original '10.0'
-          # tested ES 7.10 user_agent processor and it returns '10' as well
           expect( subject.get("[ua][os][version]") ).to eql '10'
           ua_metadata = subject.get("[@metadata][filter][user_agent][os]")
           expect( ua_metadata ).to include 'version' => { 'major' => '10' }

--- a/src/main/java/org/logstash/uaparser/UserAgent.java
+++ b/src/main/java/org/logstash/uaparser/UserAgent.java
@@ -34,14 +34,22 @@ public final class UserAgent {
 
     public final String patch;
 
-    public UserAgent(String family, String major, String minor, String patch) {
+    public final String patchMinor;
+
+    public UserAgent(String family, String major, String minor, String patch, String patchMinor) {
         this.family = family;
         this.major = major;
         this.minor = minor;
         this.patch = patch;
+        this.patchMinor = patchMinor;
     }
 
-    public static UserAgent fromMap(Map<String, String> m) {
+    UserAgent(String family, String major, String minor, String patch) {
+        this(family, major, minor, patch, null);
+    }
+
+    // test-only
+    static UserAgent fromMap(Map<String, String> m) {
         return new UserAgent(m.get("family"), m.get("major"), m.get("minor"), m.get("patch"));
     }
 
@@ -53,7 +61,8 @@ public final class UserAgent {
         return ((this.family != null && this.family.equals(o.family)) || this.family == o.family) &&
             ((this.major != null && this.major.equals(o.major)) || this.major == o.major) &&
             ((this.minor != null && this.minor.equals(o.minor)) || this.minor == o.minor) &&
-            ((this.patch != null && this.patch.equals(o.patch)) || this.patch == o.patch);
+            ((this.patch != null && this.patch.equals(o.patch)) || this.patch == o.patch) &&
+            ((this.patchMinor != null && this.patchMinor.equals(o.patchMinor)) || this.patchMinor == o.patchMinor);
     }
 
     @Override
@@ -62,17 +71,19 @@ public final class UserAgent {
         h += major == null ? 0 : major.hashCode();
         h += minor == null ? 0 : minor.hashCode();
         h += patch == null ? 0 : patch.hashCode();
+        h += patchMinor == null ? 0 : patchMinor.hashCode();
         return h;
     }
 
     @Override
     public String toString() {
         return String.format(
-            "{\"family\": %s, \"major\": %s, \"minor\": %s, \"patch\": %s}",
+            "{\"family\": %s, \"major\": %s, \"minor\": %s, \"patch\": %s, \"patchMinor\": %s}",
             family == null ? Constants.EMPTY_STRING : '"' + family + '"',
             major == null ? Constants.EMPTY_STRING : '"' + major + '"',
             minor == null ? Constants.EMPTY_STRING : '"' + minor + '"',
-            patch == null ? Constants.EMPTY_STRING : '"' + patch + '"'
+            patch == null ? Constants.EMPTY_STRING : '"' + patch + '"',
+            patchMinor == null ? Constants.EMPTY_STRING : '"' + patchMinor + '"'
         );
     }
 

--- a/src/main/java/org/logstash/uaparser/UserAgentParser.java
+++ b/src/main/java/org/logstash/uaparser/UserAgentParser.java
@@ -109,7 +109,7 @@ final class UserAgentParser {
             if (this.familyReplacement != null) {
                 if (this.familyContainsPos && groupCount >= 1 &&
                     this.matcher.group(1) != null) {
-                    family = UserAgentParser.UAPattern.FIRST_PATTERN.matcher(this.familyReplacement)
+                    family = FIRST_PATTERN.matcher(this.familyReplacement)
                         .replaceFirst(Matcher.quoteReplacement(this.matcher.group(1)));
                 } else {
                     family = this.familyReplacement;
@@ -121,33 +121,25 @@ final class UserAgentParser {
             if (this.v1Replacement != null) {
                 v1 = this.v1Replacement;
             } else if (groupCount >= 2) {
-                String group2 = this.matcher.group(2);
-                if (!isBlank(group2)) {
-                    v1 = group2;
-                }
+                v1 = nonBlank(matcher.group(2));
             }
-            String v3 = null;
-            String v2 = null;
+            String v2 = null, v3 = null, v4 = null;
             if (this.v2Replacement != null) {
                 v2 = this.v2Replacement;
             } else if (groupCount >= 3) {
-                String group3 = this.matcher.group(3);
-                if (!isBlank(group3)) {
-                    v2 = group3;
-                }
+                v2 = nonBlank(matcher.group(3));
                 if (groupCount >= 4) {
-                    String group4 = this.matcher.group(4);
-                    if (!isBlank(group4)) {
-                        v3 = group4;
+                    v3 = nonBlank(matcher.group(4));
+                    if (groupCount >= 5) {
+                        v4 = nonBlank(matcher.group(5));
                     }
                 }
             }
-            return family == null ? null : new UserAgent(family, v1, v2, v3);
+            return family == null ? null : new UserAgent(family, v1, v2, v3, v4);
         }
 
-        private boolean isBlank(String value) {
-            return value == null || value.isEmpty();
-
+        private static String nonBlank(String value) {
+            return (value == null || value.isEmpty()) ? null : value;
         }
     }
 }

--- a/src/test/java/org/logstash/uaparser/ParserTest.java
+++ b/src/test/java/org/logstash/uaparser/ParserTest.java
@@ -88,7 +88,7 @@ public class ParserTest {
 
     final Client expected1 = new Client(new UserAgent("Firefox", "3", "5", "5"),
                                   new OS("Mac OS X", "10", "4", null, null),
-                                  "Other");
+                                  "Mac");
     final Client expected2 = new Client(new UserAgent("Mobile Safari", "5", "1", null),
                                   new OS("iOS", "5", "1", "1", null),
                                   "iPhone");


### PR DESCRIPTION
**This PR makes the plugin compliant with ECS**
The schema has clear requirements and maps UA data under [`user_agent.*`](https://github.com/elastic/ecs/blob/1.7/generated/ecs/ecs_flat.yml#L8393).

Implementation wise we do so by having a `target => 'user_agent'` default in ECS mode (no target in legacy mode).

UA version was previously only provided with individual segments - matching `[major]`, `[minor]` and `[patch]` fields, for ECS we built the version back and to provide a `[user_agent][version]`, the individual parts are than available under `[@metadata][filter][user_agen]...`.

- [x] docs with an example
- [x] reach a consensus on `os.version`
- [x] confirm `prefix => foo` warning is enough or do we rather abort if it's set in ECS mode?
- [x] ~~'breaking' `[os]` in legacy mode to not be the same as `[os][name]`~~