### PR TITLE
Test: adjust user-agent test after Java parsing updates 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task downloadTestYaml(type: Download, overwrite: false) {
   dest buildDir.toPath().resolve('resources/test').toFile()
 }
 
-task verifyYaml(type: Verify, dependsOn: [patchYaml, downloadTestYaml]) {
+task verifyYaml(type: Verify, dependsOn: [patchYaml]) {
   src buildDir.toPath().resolve('resources/main/regexes.yaml').toFile()
   algorithm 'SHA1'
   checksum '5a8ea18a9c9153e83159b8662e3f6650fbca60a8' // after replacement
@@ -103,6 +103,7 @@ dependencies {
 
 test {
   dependsOn 'verifyYaml'
+  dependsOn 'downloadTestYaml'
   minHeapSize = "256m"
   maxHeapSize = "1024m"
 
@@ -116,7 +117,7 @@ test {
 apply plugin: 'com.github.johnrengelman.shadow'
 
 shadowJar {
-  dependsOn verifyYaml
+  dependsOn 'verifyYaml'
   classifier = null
 }
 

--- a/src/test/java/org/logstash/uaparser/CachingParserTest.java
+++ b/src/test/java/org/logstash/uaparser/CachingParserTest.java
@@ -17,6 +17,9 @@
  */
 package org.logstash.uaparser;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -24,14 +27,15 @@ import org.junit.Test;
  * These tests really only redo the same tests as in ParserTest but with a
  * different Parser subclass Also the same tests will be run several times on
  * the same user agents to validate the caching works correctly.
+ *
  * @author niels
+ *
  */
 public class CachingParserTest extends ParserTest {
 
-    @Override
     @Before
-    public void initParser() throws Exception {
-        this.parser = new CachingParser();
+    public void initParser() {
+        parser = new CachingParser();
     }
 
     @Override
@@ -40,59 +44,69 @@ public class CachingParserTest extends ParserTest {
     }
 
     @Test
+    public void testCachingParserCorrectSizeInit() {
+        parser = new CachingParser(10);
+    }
+
+    @Test (expected = java.lang.IllegalArgumentException.class)
+    public void testCachingParserIncorrectSizeInit() {
+        parser = new CachingParser(0);
+    }
+
+    @Test
     public void testCachedParseUserAgent() {
-        testParseUserAgent();
-        testParseUserAgent();
-        testParseUserAgent();
+        super.testParseUserAgent();
+        super.testParseUserAgent();
+        super.testParseUserAgent();
     }
 
     @Test
-    public void testCachedParseOS() throws Exception {
-        testParseOS();
-        testParseOS();
-        testParseOS();
+    public void testCachedParseOS() {
+        super.testParseOS();
+        super.testParseOS();
+        super.testParseOS();
     }
 
     @Test
-    public void testCachedParseAdditionalOS() throws Exception {
-        testParseAdditionalOS();
-        testParseAdditionalOS();
-        testParseAdditionalOS();
+    public void testCachedParseAdditionalOS() {
+        super.testParseAdditionalOS();
+        super.testParseAdditionalOS();
+        super.testParseAdditionalOS();
     }
 
     @Test
-    public void testCachedParseDevice() throws Exception {
-        testParseDevice();
-        testParseDevice();
-        testParseDevice();
+    public void testCachedParseDevice() {
+        super.testParseDevice();
+        super.testParseDevice();
+        super.testParseDevice();
     }
 
     @Test
     public void testCachedParseFirefox() {
-        testParseFirefox();
-        testParseFirefox();
-        testParseFirefox();
+        super.testParseFirefox();
+        super.testParseFirefox();
+        super.testParseFirefox();
     }
 
     @Test
     public void testCachedParsePGTS() {
-        testParsePGTS();
-        testParsePGTS();
-        testParsePGTS();
+        super.testParsePGTS();
+        super.testParsePGTS();
+        super.testParsePGTS();
     }
 
     @Test
     public void testCachedParseAll() {
-        testParseAll();
-        testParseAll();
-        testParseAll();
+        super.testParseAll();
+        super.testParseAll();
+        super.testParseAll();
     }
 
     @Test
     public void testCachedReplacementQuoting() throws Exception {
-        testReplacementQuoting();
-        testReplacementQuoting();
-        testReplacementQuoting();
+        super.testReplacementQuoting();
+        super.testReplacementQuoting();
+        super.testReplacementQuoting();
     }
 
 }

--- a/src/test/java/org/logstash/uaparser/DataTest.java
+++ b/src/test/java/org/logstash/uaparser/DataTest.java
@@ -18,14 +18,15 @@
 
 package org.logstash.uaparser;
 
-import java.util.HashSet;
-import java.util.Random;
-import org.junit.Before;
-import org.junit.Test;
-
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+
+import java.util.HashSet;
+import java.util.Random;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Abstract base class for the data class tests
@@ -88,8 +89,8 @@ public abstract class DataTest<T> {
       long seed = nextSeed();
       T first = getRandomInstance(seed, new StringGenerator(seed, false));
       T second = getRandomInstance(seed, new StringGenerator(seed, false));
-      assertThat(first, is(second));
-      assertThat(first.hashCode(), is(second.hashCode()));
+      MatcherAssert.assertThat(first, is(second));
+      MatcherAssert.assertThat(first.hashCode(), is(second.hashCode()));
     }
   }
 
@@ -99,14 +100,14 @@ public abstract class DataTest<T> {
       StringGenerator uniqueGenerator = new StringGenerator(nextSeed(), true);
       T first = getRandomInstance(nextSeed(), uniqueGenerator);
       T second = getRandomInstance(nextSeed(), uniqueGenerator);
-      assertThat(first, is(not(second)));
+      MatcherAssert.assertThat(first, is(not(second)));
     }
   }
 
   @Test
   public void testBlankInstances() {
     T first = getBlankInstance(), second = getBlankInstance();
-    assertThat(first, is(second));
-    assertThat(first.hashCode(), is(second.hashCode()));
+    MatcherAssert.assertThat(first, is(second));
+    MatcherAssert.assertThat(first.hashCode(), is(second.hashCode()));
   }
 }

--- a/src/test/java/org/logstash/uaparser/ParserTest.java
+++ b/src/test/java/org/logstash/uaparser/ParserTest.java
@@ -21,9 +21,7 @@ package org.logstash.uaparser;
 import static org.hamcrest.Matchers.is;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -156,7 +154,14 @@ public class ParserTest {
       if (testCase.containsKey("js_ua")) continue;
 
       String uaString = testCase.get("user_agent_string");
-      MatcherAssert.assertThat(uaString, parser.parseUserAgent(uaString), is(UserAgent.fromMap(testCase)));
+      UserAgent expect = UserAgent.fromMap(testCase);
+      UserAgent actual = parser.parseUserAgent(uaString);
+      // NOTE: the UA Java library does not (yet) parse patchMinor thus
+      // assert some of these WITHOUT patchMinor (like we did before) :
+      if (actual.patchMinor != null && expect.patchMinor == null) {
+        actual = new UserAgent(actual.family, actual.major, actual.minor, actual.patch);
+      }
+      MatcherAssert.assertThat(uaString, actual, is(expect));
     }
   }
 


### PR DESCRIPTION
in #68 we adjusted the Java parsing to extract matched [patch_minor](https://github.com/logstash-plugins/logstash-filter-useragent/commit/747b1611d284dcfe52841157b16b241275d2eee4#diff-4ae5859d7b7404d3b974f8973cd5c9243f96cc47146b5a11314af8b4091b8f05R134) versions as well.

the plugin's code historically relied on a 'forked' [UAP-Java](https://github.com/ua-parser/uap-java) library, the library seems to still not support parsing UA `major.minor.patch.patch_minor` but other implementation (e.g. Python/JS) do.

the reason for extracting patch_minor was that it's very common (with Chrome) to have `A.B.C.D` version strings, to reconstruct the original version missing the `.D` part seemed weird.

the original Java tests (also imported from [UAP-Java](https://github.com/ua-parser/uap-java/tree/master/src/test/java/ua_parser)) already had modifications in them, the PR here re-imports the test changes from upstream and than adds a work-around to pass tests (wout patch_minor) as before: c58f664aa5d39b3ce685e1bbb9ce1818aa923178