### PR TITLE
Fix dictionary definition passed into the spec methods

### DIFF
--- a/spec/filters/useragent_spec.rb
+++ b/spec/filters/useragent_spec.rb
@@ -354,7 +354,7 @@ describe LogStash::Filters::UserAgent do
         }
       CONFIG
 
-      sample "foo" => "bar" do
+      sample({"foo" => "bar"}) do
         expect( subject.to_hash ).to_not include("ua")
       end
 


### PR DESCRIPTION
Fix dictionary definition passed into the spec methods, to be compliant with JRuby 9.4

## How to test
Same steps as https://github.com/logstash-plugins/logstash-filter-cidr/pull/26
