### PR TITLE
[DOC] Add one more condition in `source` field

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -182,6 +182,7 @@ You can find the latest version of this here:
   * This is a required setting.
   * Value type is <<string,string>>
   * There is no default value for this setting.
+  * The value of this setting shouldn't be the same as the value of <<plugins-{type}s-{plugin}-target>>.
 
 The field containing the user agent string. If this field is an
 array, only the first value will be used.


### PR DESCRIPTION
If `source` field is the same as the `target` field, the pipeline will crash with the error something like the below:

```
[ERROR][logstash.javapipeline    ][main] Pipeline worker error, the pipeline will be stopped {:pipeline_id=>"main", :error=>"Could not set field 'name' on object 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:45.0) Gecko/20100101 Firefox/45.0' to value 'Firefox'.This is probably due to trying to set a field like [foo][bar] = someValuewhen [foo] is not either a map or a string",
```

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
